### PR TITLE
Added a limitation to the author's name length

### DIFF
--- a/src/Models/DatabaseAction.php
+++ b/src/Models/DatabaseAction.php
@@ -4,7 +4,6 @@ namespace BadChoice\Thrust\Models;
 
 use BadChoice\Thrust\Models\Enums\DatabaseActionEvent;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use LogicException;
@@ -54,10 +53,8 @@ class DatabaseAction extends Model
         return $class && class_exists($class);
     }
 
-    protected function authorName(): Attribute
+    protected function setAuthorNameAttribute(mixed $value): void
     {
-        return Attribute::make(
-            set: fn (mixed $value) => mb_substr((string) $value, 0, 100),
-        );
+        $this->attributes['author_name'] = mb_substr((string) $value, 0, 100);
     }
 }

--- a/src/Models/DatabaseAction.php
+++ b/src/Models/DatabaseAction.php
@@ -4,6 +4,7 @@ namespace BadChoice\Thrust\Models;
 
 use BadChoice\Thrust\Models\Enums\DatabaseActionEvent;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use LogicException;
@@ -51,5 +52,12 @@ class DatabaseAction extends Model
         $class = $this->getAttributeFromArray("{$key}_type");
 
         return $class && class_exists($class);
+    }
+
+    protected function authorName(): Attribute
+    {
+        return Attribute::make(
+            set: fn (mixed $value) => mb_substr((string) $value, 0, 100),
+        );
     }
 }

--- a/tests/Models/DatabaseActionTest.php
+++ b/tests/Models/DatabaseActionTest.php
@@ -4,10 +4,11 @@ namespace Tests\Models;
 
 use App\Models\Employee;
 use App\Models\Invoice;
-use BadChoice\Thrust\Models\Enums\DatabaseActionEvent;
 use BadChoice\Thrust\Models\DatabaseAction;
+use BadChoice\Thrust\Models\Enums\DatabaseActionEvent;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use LogicException;
 use Tests\TestCase;
 
@@ -128,5 +129,16 @@ final class DatabaseActionTest extends TestCase
 
         $this->assertInstanceOf(Invoice::class, $actionWithRelatedModel->model);
         $this->assertEquals(45, $actionWithRelatedModel->model->total);
+    }
+
+    public function testAuthorNameIsLimitedTo100CharsToPreventSqlErrors(): void
+    {
+        $tooLongAuthorName = Str::random(150);
+        $shortenedAuthorName = mb_substr($tooLongAuthorName, 0, 100);
+
+        $action = new DatabaseAction();
+        $action->author_name = $tooLongAuthorName;
+
+        $this->assertEquals($shortenedAuthorName, $action->author_name);
     }
 }


### PR DESCRIPTION
Com que el valor de l'author_name es pot posar amb una callback he afegit un accessor que el retalla i així ens estalviem errors d'SQL.