### PR TITLE
REV-12144: hide Thrust Resource delete action when forbidden

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -270,7 +270,7 @@ abstract class Resource
     public function actions()
     {
         return [
-            new Delete(),
+            ...($this->canDelete(self::$model) ? [new Delete()] : []),
         ];
     }
 


### PR DESCRIPTION
The goal is to avoid showing an action that the user cannot perform.