### PR TITLE
Fix sortable count and ajax select required

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -239,7 +239,7 @@ abstract class Resource
         }
 
         if (static::$sortable) {
-            $object->{static::$sortField} = $this->getBaseQuery()->withTrashed()->count();
+            $object->{static::$sortField} = $this->getBaseQuery()->orderBy(static::$sortField, 'DESC')->first()?->{static::$sortField} + 1;
         }
         return $object;
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -239,7 +239,7 @@ abstract class Resource
         }
 
         if (static::$sortable) {
-            $object->{static::$sortField} = $this->count();
+            $object->{static::$sortField} = $this->getBaseQuery()->withTrashed()->count();
         }
         return $object;
     }

--- a/src/resources/views/fields/selectAjax.blade.php
+++ b/src/resources/views/fields/selectAjax.blade.php
@@ -1,5 +1,5 @@
 @component('thrust::components.formField', ["field" => $field, "title" => $title, "description" => $description ?? null, "inline" => $inline])
-    <select id="{{$field}}" name="{{$field}}">
+    <select id="{{$field}}" @if(!$allowNull) required @endif name="{{$field}}">
         <option value="{{$value}}" selected>{{$name}}</option>
     </select>
     @if(isset($inlineCreation) && $inlineCreation)


### PR DESCRIPTION
When to elements of a sort list are deleted and a new one is added it might be added before another one.
Example:
Element1 order = 1
Element2 order = 2
Element3 order = 3
Element4 order = 4

Delete element 2 and 3 and add element5
Element1 order = 1
Element4 order = 4
Element5 order = 3

With updated code element 5 will be added as so:
Element1 order = 1
Element4 order = 4
Element5 order = 5

We also add required to ajaxSelect when allowNull is set to false:
![image](https://github.com/revosystems/thrust/assets/8748692/b7de7ae0-5e67-45b6-a38c-53f2f0ac3833)
