### PR TITLE
Fix actions loader

### DIFF
--- a/src/resources/views/components/actions.blade.php
+++ b/src/resources/views/components/actions.blade.php
@@ -4,7 +4,7 @@
         <x-ui::dropdown :offset="14" :arrow="true">
             <x-slot name="trigger">
             <x-ui::secondary-button>
-                <div class="flex items-center space-x-2">
+                <div class="flex items-center gap-2">
                     <div class="sm:hidden">
                         <x-ui::icon>ellipsis</x-ui::icon>
                     </div>

--- a/src/resources/views/components/actions.blade.php
+++ b/src/resources/views/components/actions.blade.php
@@ -8,7 +8,9 @@
                     <div class="sm:hidden">
                         <x-ui::icon>ellipsis</x-ui::icon>
                     </div>
-                    <i id='actions-loading' class="fa fa-circle-o-notch fa-spin fa-fw hidden"></i>
+                    <div id='actions-loading' class="hidden">
+                        <i class="fa fa-circle-notch fa-spin fa-fw"></i>
+                    </div>
                     <div class="hidden sm:block">
                         {{ __("thrust::messages.actions") }} @icon(caret-down)
                     </div>


### PR DESCRIPTION
circle-notch instead of circle-o-notch since its the correct version from the vendor files.
gap instead of space-x otherwise it detects the ellipsis icon even when hidden and adds margin.