### PR TITLE
fix!: removed closures from observer to fix a serialize crash on jobs

### DIFF
--- a/src/Contracts/DatabaseActionAuthor.php
+++ b/src/Contracts/DatabaseActionAuthor.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace BadChoice\Thrust\Contracts;
+
+interface DatabaseActionAuthor
+{
+    public function name(): string;
+
+    public function type(): ?string;
+
+    public function id(): ?int;
+}

--- a/src/Models/DatabaseActionDefaultAuthor.php
+++ b/src/Models/DatabaseActionDefaultAuthor.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace BadChoice\Thrust\Models;
+
+use BadChoice\Thrust\Contracts\DatabaseActionAuthor;
+
+final class DatabaseActionDefaultAuthor implements DatabaseActionAuthor
+{
+    public function name(): string
+    {
+         if (app()->runningInConsole() && ! app()->runningUnitTests()) {
+            return $this->runningCommand();
+        }
+
+        return auth()->user()?->email ?? 'Unknown';
+    }
+
+    public function type(): ?string
+    {
+        $user = auth()->user();
+
+        return $user ? $user::class : null;
+    }
+
+    public function id(): ?int
+    {
+        $id = auth()->id();
+
+        return is_string($id) ? intval($id) : $id;
+    }
+
+    private function runningCommand(): string
+    {
+        $command = request()->server('argv');
+        if (is_array($command)) {
+            $command = implode(' ', $command);
+        }
+        return "php {$command}";
+    }
+}

--- a/src/ThrustServiceProvider.php
+++ b/src/ThrustServiceProvider.php
@@ -34,7 +34,7 @@ class ThrustServiceProvider extends ServiceProvider
 
     public function register()
     {
-        app()->singleton(ResourceManager::class, fn () => new ResourceManager);
-        app()->singleton(ThrustObserver::class, fn () => new ThrustObserver);
+        $this->app->singleton(ResourceManager::class, fn () => new ResourceManager);
+        $this->app->singleton(ThrustObserver::class, fn () => new ThrustObserver);
     }
 }


### PR DESCRIPTION
https://linear.app/revo/issue/REV-15904/bug-del-thrustobserver-quan-sexecuten-jobs

El problema és que el Thrust Observer que s'encarrega de les Database Actions tenia propietats de tipus Closure i quan es serialitzava l'objecte per a fer un job petava perquè les Closures no es poden serialitzar.

En aquest PR he canviat les Closures per una Classe però això és un BREAKING CHANGE

La idea és que a XEF en comptes de fer això
``` 
ThrustObserver::enable(config('database.observer.enabled'));
ThrustObserver::register();
ThrustObserver::setAuthorModelCallback(fn () => auth()->user()?->innerUser() ?? auth()->user());
ThrustObserver::setAuthorNameCallback(fn () => auth()->user()?->innerUserName());
```
es pugui fer això
``` 
ThrustObserver::enable(config('database.observer.enabled'));
ThrustObserver::register();
ThrustObserver::author(new Author);
```
Aquesta classe Author hauria de complir el contracte DatabaseActionAuthor d'aquest PR