### PR TITLE
edit inline dejavu styles

### DIFF
--- a/src/resources/views/belongsToManyEditInline.blade.php
+++ b/src/resources/views/belongsToManyEditInline.blade.php
@@ -1,25 +1,26 @@
-
 @if ($sortable)
-    <td class="sort action hide-mobile"></td>
+    <x-ui::table.cell class="sort action hide-mobile"></x-ui::table.cell>
 @endif
 <form action="{{route('thrust.update', [$resourceName, $object->id] )}}" id='thrust-form-{{$object->id}}' method="POST" onkeydown="console.log(event.key)">
     @if (! $belongsToManyField->hideName)
-        <td> {{ $relatedName }} </td>
+        <x-ui::table.cell>{{ $relatedName }}</x-ui::table.cell>
     @endif
     @foreach($belongsToManyField->objectFields as $field)
-        <td></td>
+        <x-ui::table.cell></x-ui::table.cell>
     @endforeach
     @foreach($fields as $field)
-        <td class="{{$field->rowClass}}">
+        <x-ui::table.cell class="{{$field->rowClass}}">
             @if ($field->showInEdit)
                 {!! $field->displayInEdit($object, true) !!}
             @endif
-        </td>
+        </x-ui::table.cell>
     @endforeach
-    <td colspan="2">
+    <x-ui::table.cell colspan="2">
         {{ method_field('PUT') }}
         {{ csrf_field() }}
         <input type="hidden" name="inline" value="1">
-        <button class="button secondary" onclick="submitInlineForm({{$object->id}}); event.preventDefault();" form="thrust-form-{{ $object->id }}"> {{ __("thrust::messages.save") }} </button>
-    </td>
+        <x-ui::tertiary-button onclick="submitInlineForm({{$object->id}}); event.preventDefault();" form="thrust-form-{{ $object->id }}">
+            {{ __("thrust::messages.save") }}
+        </x-ui::tertiary-button>
+    </x-ui::table.cell>
 </form>


### PR DESCRIPTION
Linear: https://linear.app/revo/issue/REV-15244/actualitzar-thrust-sidecar-amb-lo-nou-de-xef-responsive