### PR TITLE
feature: custom delete messages!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "laravel/framework": "^8.0|^9.0|^10.0",
         "intervention/image": "^2.5",
         "psr/container": "^1.0|^2.0",
-        "revosystems/dejavu": "^0.1.49"
+        "revosystems/dejavu": "^0.1.53"
     },
     "require-dev": {
         "orchestra/testbench": "^7.17",

--- a/src/Fields/Delete.php
+++ b/src/Fields/Delete.php
@@ -24,9 +24,9 @@ class Delete extends Field {
             'link' => route('thrust.delete', [Thrust::resourceNameFromModel($object), $object->id]),
             'title' => null,
             'icon' => 'trash',
-            'confirm' => htmlentities($this->getDeleteConfirmationMessage(), ENT_QUOTES),
+            'confirm' => $this->getConfirmMessage(),
             'deletion' => true,
-            'message' => $this->getMessage($object)
+            'message' => $this->displayMessage($object)
         ]);
     }
 
@@ -38,6 +38,17 @@ class Delete extends Field {
         return $this;
     }
 
+    protected function displayMessage($object) {
+        return empty($this->getMessage($object)) 
+            ? $this->getDefaultMessage($object) 
+            : $this->getMessage($object);
+    }
+
+    protected function getConfirmMessage(): string
+    {
+        return __("thrust::messages.deleteResource");
+    }
+
     protected function getMessage(mixed $object): string
     {
         if ($this->message instanceof Closure) {
@@ -45,6 +56,11 @@ class Delete extends Field {
         }
 
         return $this->message;
+    }
+
+    protected function getDefaultMessage(mixed $object): string
+    {
+        return __("thrust::messages.deleteResourceDesc", ['resourceName' => $object->name]);
     }
 
 }

--- a/src/Fields/Delete.php
+++ b/src/Fields/Delete.php
@@ -3,6 +3,7 @@
 namespace BadChoice\Thrust\Fields;
 
 use BadChoice\Thrust\Facades\Thrust;
+use Closure;
 
 class Delete extends Field {
 
@@ -11,6 +12,7 @@ class Delete extends Field {
     public string $rowClass          = '!py-0 !px-0 w-8 sm:w-10 text-center';
     public $policyAction             = 'delete';
     public bool $importable          = false;
+    public Closure|string $message   = '';
 
     public function displayInIndex($object)
     {
@@ -23,16 +25,26 @@ class Delete extends Field {
             'title' => null,
             'icon' => 'trash',
             'confirm' => htmlentities($this->getDeleteConfirmationMessage(), ENT_QUOTES),
-            'deletion' => true
+            'deletion' => true,
+            'message' => $this->getMessage($object)
         ]);
-
-        //$link = route('thrust.delete', [Thrust::resourceNameFromModel($object), $object->id]);
-        //$escapedConfirmMessage = htmlentities($this->getDeleteConfirmationMessage(), ENT_QUOTES);
-        //return "<a class='delete-resource thrust-delete'".
-        //    ( $this->deleteConfirmationMessage ? "data-delete='resource confirm' confirm-message='{$escapedConfirmMessage}'" : "data-delete='resource'") .
-        //    " href='{$link}'>Delete</a>";
     }
 
     public function displayInEdit($object, $inline = false){ }
+
+    public function withMessage(Closure|string $message): self
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    protected function getMessage(mixed $object): string
+    {
+        if ($this->message instanceof Closure) {
+            return ($this->message)($object);
+        }
+
+        return $this->message;
+    }
 
 }

--- a/src/resources/lang/ca/messages.php
+++ b/src/resources/lang/ca/messages.php
@@ -31,6 +31,6 @@ return [
     'retryImport'            => 'Tornar a importar',
     'learnMore'              => 'Saber-ne més',
     'globalSearchNoResultsFor' => 'Sense resultats per',
-    'deleteResource'         => 'Eliminar recurs',
-    'deleteResourceDesc'     => 'Estas segur que vols eliminar el recurs ":resourceName"?. Aquesta acció no es pot desfer.',
+    'deleteResource'         => 'Confirmar eliminació',
+    'deleteResourceDesc'     => 'Estàs a punt d\'eliminar ":resourceName" de la base de dades. Aquesta acció no es pot desfer. Estàs segur que vols continuar?',
 ];

--- a/src/resources/lang/ca/messages.php
+++ b/src/resources/lang/ca/messages.php
@@ -32,5 +32,6 @@ return [
     'learnMore'              => 'Saber-ne més',
     'globalSearchNoResultsFor' => 'Sense resultats per',
     'deleteResource'         => 'Confirmar eliminació',
-    'deleteResourceDesc'     => 'Estàs a punt d\'eliminar ":resourceName" de la base de dades. Aquesta acció no es pot desfer. Estàs segur que vols continuar?',
+    'deleteResourceDesc'     => 'Estàs a punt d\'eliminar <b>:resourceName</b> de la base de dades. Aquesta acció no es pot desfer. Estàs segur que vols continuar?',
+    'confirmDelete'          => 'Estàs segur que vols eliminar?',
 ];

--- a/src/resources/lang/ca/messages.php
+++ b/src/resources/lang/ca/messages.php
@@ -31,4 +31,6 @@ return [
     'retryImport'            => 'Tornar a importar',
     'learnMore'              => 'Saber-ne més',
     'globalSearchNoResultsFor' => 'Sense resultats per',
+    'deleteResource'         => 'Eliminar recurs',
+    'deleteResourceDesc'     => 'Estas segur que vols eliminar el recurs ":resourceName"?. Aquesta acció no es pot desfer.',
 ];

--- a/src/resources/lang/de/messages.php
+++ b/src/resources/lang/de/messages.php
@@ -30,5 +30,6 @@ return [
     'importFailed'           => 'Import fehlgeschlagen',
     'retryImport'            => 'Import erneut versuchen',
     'deleteResource'         => 'Löschung bestätigen',
-    'deleteResourceDesc'     => 'Sie sind dabei, ":resourceName" aus der Datenbank zu löschen. Diese Aktion kann nicht rückgängig gemacht werden. Sind Sie sicher, dass Sie fortfahren möchten?',
+    'deleteResourceDesc'     => 'Sie sind dabei, <b>:resourceName</b> aus der Datenbank zu löschen. Diese Aktion kann nicht rückgängig gemacht werden. Sind Sie sicher, dass Sie fortfahren möchten?',
+    'confirmDelete'          => 'Sind Sie sicher, dass Sie dies löschen wollen?',
 ];

--- a/src/resources/lang/de/messages.php
+++ b/src/resources/lang/de/messages.php
@@ -28,5 +28,7 @@ return [
     'rowsToImport'           => 'Zeilen zum Importieren',
     'next'                   => 'Weiter',
     'importFailed'           => 'Import fehlgeschlagen',
-    'retryImport'            => 'Import erneut versuchen'
+    'retryImport'            => 'Import erneut versuchen',
+    'deleteResource'         => 'Ressource löschen',
+    'deleteResourceDesc'     => 'Sind Sie sicher, dass Sie die Ressource ":resourceName" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.',
 ];

--- a/src/resources/lang/de/messages.php
+++ b/src/resources/lang/de/messages.php
@@ -29,6 +29,6 @@ return [
     'next'                   => 'Weiter',
     'importFailed'           => 'Import fehlgeschlagen',
     'retryImport'            => 'Import erneut versuchen',
-    'deleteResource'         => 'Ressource löschen',
-    'deleteResourceDesc'     => 'Sind Sie sicher, dass Sie die Ressource ":resourceName" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.',
+    'deleteResource'         => 'Löschung bestätigen',
+    'deleteResourceDesc'     => 'Sie sind dabei, ":resourceName" aus der Datenbank zu löschen. Diese Aktion kann nicht rückgängig gemacht werden. Sind Sie sicher, dass Sie fortfahren möchten?',
 ];

--- a/src/resources/lang/en/messages.php
+++ b/src/resources/lang/en/messages.php
@@ -31,4 +31,6 @@ return [
     'retryImport'            => 'Import again',
     'learnMore'              => 'Learn more',
     'globalSearchNoResultsFor' => 'No results for',
+    'deleteResource'         => 'Delete resource',
+    'deleteResourceDesc'     => 'Are you sure you want to delete the resource ":resourceName"? This action cannot be undone.',
 ];

--- a/src/resources/lang/en/messages.php
+++ b/src/resources/lang/en/messages.php
@@ -31,6 +31,6 @@ return [
     'retryImport'            => 'Import again',
     'learnMore'              => 'Learn more',
     'globalSearchNoResultsFor' => 'No results for',
-    'deleteResource'         => 'Delete resource',
-    'deleteResourceDesc'     => 'Are you sure you want to delete the resource ":resourceName"? This action cannot be undone.',
+    'deleteResource'         => 'Confirm deletion',
+    'deleteResourceDesc'     => 'You are about to delete ":resourceName" from the database. This action cannot be undone. Are you sure you want to proceed?',
 ];

--- a/src/resources/lang/en/messages.php
+++ b/src/resources/lang/en/messages.php
@@ -32,5 +32,6 @@ return [
     'learnMore'              => 'Learn more',
     'globalSearchNoResultsFor' => 'No results for',
     'deleteResource'         => 'Confirm deletion',
-    'deleteResourceDesc'     => 'You are about to delete ":resourceName" from the database. This action cannot be undone. Are you sure you want to proceed?',
+    'deleteResourceDesc'     => 'You are about to delete <b>:resourceName</b> from the database. This action cannot be undone. Are you sure you want to proceed?',
+    'confirmDelete'          => 'Are you sure you want to delete?',
 ];

--- a/src/resources/lang/es/messages.php
+++ b/src/resources/lang/es/messages.php
@@ -32,5 +32,6 @@ return [
     'learnMore'              => 'Saber más',
     'globalSearchNoResultsFor' => 'Sin resultados para',
     'deleteResource'         => 'Confirmar eliminación',
-    'deleteResourceDesc'     => 'Estás a punto de eliminar ":resourceName" de la base de datos. Esta acción no se puede deshacer. ¿Estás seguro de que deseas continuar?',
+    'deleteResourceDesc'     => 'Estás a punto de eliminar <b>:resourceName</b> de la base de datos. Esta acción no se puede deshacer. ¿Estás seguro de que deseas continuar?',
+    'confirmDelete'          => '¿Estás seguro que quieres eliminar?',
 ];

--- a/src/resources/lang/es/messages.php
+++ b/src/resources/lang/es/messages.php
@@ -31,4 +31,6 @@ return [
     'retryImport'            => 'Volver a importar',
     'learnMore'              => 'Saber más',
     'globalSearchNoResultsFor' => 'Sin resultados para',
+    'deleteResource'         => 'Eliminar recurso',
+    'deleteResourceDesc'     => '¿Estás seguro de que quieres eliminar el recurso ":resourceName"? Esta acción no se puede deshacer.',
 ];

--- a/src/resources/lang/es/messages.php
+++ b/src/resources/lang/es/messages.php
@@ -31,6 +31,6 @@ return [
     'retryImport'            => 'Volver a importar',
     'learnMore'              => 'Saber más',
     'globalSearchNoResultsFor' => 'Sin resultados para',
-    'deleteResource'         => 'Eliminar recurso',
-    'deleteResourceDesc'     => '¿Estás seguro de que quieres eliminar el recurso ":resourceName"? Esta acción no se puede deshacer.',
+    'deleteResource'         => 'Confirmar eliminación',
+    'deleteResourceDesc'     => 'Estás a punto de eliminar ":resourceName" de la base de datos. Esta acción no se puede deshacer. ¿Estás seguro de que deseas continuar?',
 ];

--- a/src/resources/lang/eu/messages.php
+++ b/src/resources/lang/eu/messages.php
@@ -29,6 +29,6 @@ return [
     'next'                   => 'Hurrengoa',
     'importFailed'           => 'Inportazioa huts egin du',
     'retryImport'            => 'Inportazioa saiatu berriro',
-    'deleteResource'         => 'Baliabidea ezabatu',
-    'deleteResourceDesc'     => 'Ziur zaude ":resourceName" baliabidea ezabatu nahi duzula? Ekintza hau ezin da desegin.',
+    'deleteResource'         => 'Ezabatzea baieztatu',
+    'deleteResourceDesc'     => '":resourceName" datu-basetik ezabatzen ari zara. Ekintza hau ezin da desegin. Ziur jarraitu nahi duzula?',
 ];

--- a/src/resources/lang/eu/messages.php
+++ b/src/resources/lang/eu/messages.php
@@ -30,5 +30,6 @@ return [
     'importFailed'           => 'Inportazioa huts egin du',
     'retryImport'            => 'Inportazioa saiatu berriro',
     'deleteResource'         => 'Ezabatzea baieztatu',
-    'deleteResourceDesc'     => '":resourceName" datu-basetik ezabatzen ari zara. Ekintza hau ezin da desegin. Ziur jarraitu nahi duzula?',
+    'deleteResourceDesc'     => '<b>:resourceName</b> datu-basetik ezabatzen ari zara. Ekintza hau ezin da desegin. Ziur jarraitu nahi duzula?',
+    'confirmDelete'          => 'Ezabatu nahi duzula ziur al zaude?',
 ];

--- a/src/resources/lang/eu/messages.php
+++ b/src/resources/lang/eu/messages.php
@@ -28,5 +28,7 @@ return [
     'rowsToImport'           => 'Inportatu beharreko errenkadak',
     'next'                   => 'Hurrengoa',
     'importFailed'           => 'Inportazioa huts egin du',
-    'retryImport'            => 'Inportazioa saiatu berriro'
+    'retryImport'            => 'Inportazioa saiatu berriro',
+    'deleteResource'         => 'Baliabidea ezabatu',
+    'deleteResourceDesc'     => 'Ziur zaude ":resourceName" baliabidea ezabatu nahi duzula? Ekintza hau ezin da desegin.',
 ];

--- a/src/resources/lang/fr/messages.php
+++ b/src/resources/lang/fr/messages.php
@@ -29,4 +29,6 @@ return [
     'next'                   => 'Suivant',
     'importFailed'           => 'Échec de l\'importation',
     'retryImport'            => 'Importer à nouveau',
+    'deleteResource'         => 'Supprimer la ressource',
+    'deleteResourceDesc'     => 'Êtes-vous sûr de vouloir supprimer la ressource ":resourceName"? Cette action est irréversible.',
 ];

--- a/src/resources/lang/fr/messages.php
+++ b/src/resources/lang/fr/messages.php
@@ -30,5 +30,6 @@ return [
     'importFailed'           => 'Échec de l\'importation',
     'retryImport'            => 'Importer à nouveau',
     'deleteResource'         => 'Confirmer la suppression',
-    'deleteResourceDesc'     => 'Vous êtes sur le point de supprimer ":resourceName" de la base de données. Cette action est irréversible. Êtes-vous sûr de vouloir continuer?',
+    'deleteResourceDesc'     => 'Vous êtes sur le point de supprimer <b>:resourceName</b> de la base de données. Cette action est irréversible. Êtes-vous sûr de vouloir continuer?',
+    'confirmDelete'          => 'Es-tu sûr de vouloir supprimer?',
 ];

--- a/src/resources/lang/fr/messages.php
+++ b/src/resources/lang/fr/messages.php
@@ -29,6 +29,6 @@ return [
     'next'                   => 'Suivant',
     'importFailed'           => 'Échec de l\'importation',
     'retryImport'            => 'Importer à nouveau',
-    'deleteResource'         => 'Supprimer la ressource',
-    'deleteResourceDesc'     => 'Êtes-vous sûr de vouloir supprimer la ressource ":resourceName"? Cette action est irréversible.',
+    'deleteResource'         => 'Confirmer la suppression',
+    'deleteResourceDesc'     => 'Vous êtes sur le point de supprimer ":resourceName" de la base de données. Cette action est irréversible. Êtes-vous sûr de vouloir continuer?',
 ];

--- a/src/resources/lang/it/messages.php
+++ b/src/resources/lang/it/messages.php
@@ -29,6 +29,6 @@ return [
     'next'                   => 'Avanti',
     'importFailed'           => 'Importazione fallita',
     'retryImport'            => 'Riprova l\'importazione',
-    'deleteResource'         => 'Elimina risorsa',
-    'deleteResourceDesc'     => 'Sei sicuro di voler eliminare la risorsa ":resourceName"? Questa azione non può essere annullata.',
+    'deleteResource'         => 'Conferma eliminazione',
+    'deleteResourceDesc'     => 'Stai per eliminare ":resourceName" dal database. Questa azione non può essere annullata. Sei sicuro di voler procedere?',
 ];

--- a/src/resources/lang/it/messages.php
+++ b/src/resources/lang/it/messages.php
@@ -28,5 +28,7 @@ return [
     'rowsToImport'           => 'Righe da importare',
     'next'                   => 'Avanti',
     'importFailed'           => 'Importazione fallita',
-    'retryImport'            => 'Riprova l\'importazione'
+    'retryImport'            => 'Riprova l\'importazione',
+    'deleteResource'         => 'Elimina risorsa',
+    'deleteResourceDesc'     => 'Sei sicuro di voler eliminare la risorsa ":resourceName"? Questa azione non può essere annullata.',
 ];

--- a/src/resources/lang/it/messages.php
+++ b/src/resources/lang/it/messages.php
@@ -30,5 +30,6 @@ return [
     'importFailed'           => 'Importazione fallita',
     'retryImport'            => 'Riprova l\'importazione',
     'deleteResource'         => 'Conferma eliminazione',
-    'deleteResourceDesc'     => 'Stai per eliminare ":resourceName" dal database. Questa azione non può essere annullata. Sei sicuro di voler procedere?',
+    'deleteResourceDesc'     => 'Stai per eliminare <b>:resourceName</b> dal database. Questa azione non può essere annullata. Sei sicuro di voler procedere?',
+    'confirmDelete'          => 'Sei sicuro di voler eliminare?',
 ];

--- a/src/resources/lang/ptbr/messages.php
+++ b/src/resources/lang/ptbr/messages.php
@@ -29,4 +29,6 @@ return [
     'next'                   => 'Próximo',
     'importFailed'           => 'Falha na importação',
     'retryImport'            => 'Importar novamente',
+    'deleteResource'         => 'Excluir recurso',
+    'deleteResourceDesc'     => 'Você tem certeza de que deseja excluir o recurso ":resourceName"? Esta ação não pode ser desfeita.',
 ];

--- a/src/resources/lang/ptbr/messages.php
+++ b/src/resources/lang/ptbr/messages.php
@@ -30,5 +30,6 @@ return [
     'importFailed'           => 'Falha na importação',
     'retryImport'            => 'Importar novamente',
     'deleteResource'         => 'Confirmar exclusão',
-    'deleteResourceDesc'     => 'Você está prestes a excluir ":resourceName" do banco de dados. Esta ação não pode ser desfeita. Tem certeza de que deseja continuar?',
+    'deleteResourceDesc'     => 'Você está prestes a excluir <b>:resourceName</b> do banco de dados. Esta ação não pode ser desfeita. Tem certeza de que deseja continuar?',
+    'confirmDelete'          => 'Você tem certeza de que deseja excluir?',
 ];

--- a/src/resources/lang/ptbr/messages.php
+++ b/src/resources/lang/ptbr/messages.php
@@ -29,6 +29,6 @@ return [
     'next'                   => 'Próximo',
     'importFailed'           => 'Falha na importação',
     'retryImport'            => 'Importar novamente',
-    'deleteResource'         => 'Excluir recurso',
-    'deleteResourceDesc'     => 'Você tem certeza de que deseja excluir o recurso ":resourceName"? Esta ação não pode ser desfeita.',
+    'deleteResource'         => 'Confirmar exclusão',
+    'deleteResourceDesc'     => 'Você está prestes a excluir ":resourceName" do banco de dados. Esta ação não pode ser desfeita. Tem certeza de que deseja continuar?',
 ];

--- a/src/resources/lang/zh/messages.php
+++ b/src/resources/lang/zh/messages.php
@@ -29,6 +29,6 @@ return [
     'next'                   => '下一步',
     'importFailed'           => '导入失败',
     'retryImport'            => '重试导入',
-    'deleteResource'         => '删除资源',
-    'deleteResourceDesc'     => '您确定要删除资源“:resourceName”吗? 此操作无法撤销。',
+    'deleteResource'         => '确认删除',
+    'deleteResourceDesc'     => '您即将从数据库中删除 ":resourceName"。此操作无法撤销。您确定要继续吗?',
 ];

--- a/src/resources/lang/zh/messages.php
+++ b/src/resources/lang/zh/messages.php
@@ -28,5 +28,7 @@ return [
     'rowsToImport'           => '要导入的行',
     'next'                   => '下一步',
     'importFailed'           => '导入失败',
-    'retryImport'            => '重试导入'
+    'retryImport'            => '重试导入',
+    'deleteResource'         => '删除资源',
+    'deleteResourceDesc'     => '您确定要删除资源“:resourceName”吗? 此操作无法撤销。',
 ];

--- a/src/resources/lang/zh/messages.php
+++ b/src/resources/lang/zh/messages.php
@@ -30,5 +30,6 @@ return [
     'importFailed'           => '导入失败',
     'retryImport'            => '重试导入',
     'deleteResource'         => '确认删除',
-    'deleteResourceDesc'     => '您即将从数据库中删除 ":resourceName"。此操作无法撤销。您确定要继续吗?',
+    'deleteResourceDesc'     => '您即将从数据库中删除 <b>:resourceName</b>。此操作无法撤销。您确定要继续吗?',
+    'confirmDelete'          => '您确定要删除吗',
 ];

--- a/src/resources/views/actions/deleteRow.blade.php
+++ b/src/resources/views/actions/deleteRow.blade.php
@@ -1,10 +1,27 @@
-<form action="{{$link}}" method="post">
-    @csrf()
-    @method('DELETE')
-    <x-ui::tertiary-button type="submit" :async="true" x-ref="button" :confirm="$confirm">
-        <div class="flex items-center space-x-2">
-            @if($icon) <x-ui::icon>{{$icon}}</x-ui::icon>@endif
-            @if($title)<div class="hidden sm:block">{{ $title }}</div>@endif
-        </div>
-    </x-ui::tertiary-button>
-</form>
+<x-ui::modal.bottom maxWidth="{{$message ? 'xl' : 'sm'}}">
+    <x-slot name="trigger">
+        <x-ui::tertiary-button type="button">
+            <div class="flex items-center space-x-2">
+                @if($icon) <x-ui::icon>{{$icon}}</x-ui::icon>@endif
+                @if($title)<div class="hidden sm:block">{{ $title }}</div>@endif
+            </div>
+        </x-ui::tertiary-button>
+    </x-slot>
+
+    <div class="relative p-4">
+        <form action="{{$link}}" method="post">
+            @csrf()
+            @method('DELETE')
+            <x-ui::h2 class="mb-4">{{ $confirm }}</x-ui::h2>
+            
+            @if ($message)
+                <p class="mb-8">{{ $message }}</p>
+            @endif
+
+            <div class="flex justify-center gap-4 items-center">
+                <x-ui::secondary-button type="button" x-on:click="show=false">{{ __('admin.cancel') }}</x-ui::secondary-button>
+                <x-ui::primary-button type="submit" :async="true" x-ref="button" autofocus>{{ __('thrust::messages.delete') }}</x-ui::primary-button>
+            </div>
+        </form>
+    </div>
+</x-ui::modal.bottom>

--- a/src/resources/views/actions/deleteRow.blade.php
+++ b/src/resources/views/actions/deleteRow.blade.php
@@ -1,4 +1,4 @@
-<x-ui::modal.bottom maxWidth="{{$message ? 'xl' : 'sm'}}">
+<x-ui::modal.bottom maxWidth="sm">
     <x-slot name="trigger">
         <x-ui::tertiary-button type="button">
             <div class="flex items-center space-x-2">
@@ -8,19 +8,19 @@
         </x-ui::tertiary-button>
     </x-slot>
 
-    <div class="relative p-4">
+    <div class="relative p-6">
         <form action="{{$link}}" method="post">
             @csrf()
             @method('DELETE')
-            <x-ui::h2 class="mb-4">{{ $confirm }}</x-ui::h2>
+            <x-ui::h2 class="mb-4 text-left">{{ $confirm }}</x-ui::h2>
             
             @if ($message)
-                <p class="mb-8">{{ $message }}</p>
+                <p class="mb-8 text-left">{!! $message !!}</p>
             @endif
 
-            <div class="flex justify-center gap-4 items-center">
-                <x-ui::secondary-button type="button" x-on:click="show=false">{{ __('admin.cancel') }}</x-ui::secondary-button>
-                <x-ui::primary-button type="submit" :async="true" x-ref="button" autofocus>{{ __('thrust::messages.delete') }}</x-ui::primary-button>
+            <div class="flex gap-4 items-center">
+                <x-ui::secondary-button type="button" x-on:click="show=false" class="grow">{{ __('admin.cancel') }}</x-ui::secondary-button>
+                <x-ui::primary-button type="submit" :async="true" x-ref="button" class="grow" autofocus>{{ __('thrust::messages.delete') }}</x-ui::primary-button>
             </div>
         </form>
     </div>

--- a/src/resources/views/belongsToManyTable.blade.php
+++ b/src/resources/views/belongsToManyTable.blade.php
@@ -46,7 +46,7 @@
             @endforeach
             @if (app(BadChoice\Thrust\ResourceGate::class)->can($pivotResourceName, 'delete', $row->pivot))
                 <x-ui::table.cell class="w-10">
-                    <a class="delete-resource" data-delete="confirm resource" confirm-message="{{ __('admin.confirmDelete') }}" href="{{route('thrust.belongsToMany.delete', [$resourceName, $object->id, $belongsToManyField->field, $row->pivot->id])}}">
+                    <a class="delete-resource" data-delete="confirm resource" confirm-message="{{ __('thrust::messages.confirmDelete') }}" href="{{route('thrust.belongsToMany.delete', [$resourceName, $object->id, $belongsToManyField->field, $row->pivot->id])}}">
                         <x-ui::tertiary-button>@icon(trash)</x-ui::tertiary-button>
                     </a>
                 </x-ui::table.cell>


### PR DESCRIPTION
Thrust ara implementa la confirmació de borrar un recurs amb dejavu!!

A més, pots afegir un missatge extra per posar a sota de la confirmació, i pots fer que sigui condicional per a cada objecte amb un callback. Per exemple:

```
protected function editAndDeleteFields()
    {
        return [
            Edit::make('edit'), 
            Delete::make('delete')->withMessage(function (SuggestedSaleModel $object) {
                return $object->rules()->count() > 0 ? __('admin.sure_delete_suggestedSaleDesc') : '';
            })
        ];
    }
```

O simplement passar-li un missatge genèric com a:
`Delete::make('delete')->withMessage('foo')`