### PR TITLE
feature: thrust now able to boot traits

### DIFF
--- a/src/ChildResource.php
+++ b/src/ChildResource.php
@@ -13,6 +13,7 @@ abstract class ChildResource extends Resource
 
     public function __construct()
     {
+        parent::__construct();
         $this->parentId = request('parent_id');
     }
 

--- a/src/Concerns/BootableResource.php
+++ b/src/Concerns/BootableResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BadChoice\Thrust\Concerns;
+
+trait BootableResource
+{
+    /**
+     * @var array The resources that have already been booted
+     */
+    protected static $booted = [];
+
+    public function __construct() {
+        if (! isset(static::$booted[static::class])) {
+            static::$booted[static::class] = true;
+
+            static::bootTraits();
+        }
+    }
+
+    protected static function bootTraits()
+    {
+        $class = static::class;
+        
+        $booted = [];
+        
+        foreach (class_uses_recursive($class) as $trait) {
+            $method = 'boot'.class_basename($trait);
+
+            if (method_exists($class, $method) && ! in_array($method, $booted)) {
+                forward_static_call([$class, $method]);
+
+                $booted[] = $method;
+            }
+        }
+    }
+}

--- a/src/Concerns/BootableResource.php
+++ b/src/Concerns/BootableResource.php
@@ -4,19 +4,6 @@ namespace BadChoice\Thrust\Concerns;
 
 trait BootableResource
 {
-    /**
-     * @var array The resources that have already been booted
-     */
-    protected static $booted = [];
-
-    public function __construct() {
-        if (! isset(static::$booted[static::class])) {
-            static::$booted[static::class] = true;
-
-            static::bootTraits();
-        }
-    }
-
     protected static function bootTraits()
     {
         $class = static::class;

--- a/src/Concerns/BootableResource.php
+++ b/src/Concerns/BootableResource.php
@@ -4,6 +4,15 @@ namespace BadChoice\Thrust\Concerns;
 
 trait BootableResource
 {
+    protected static function bootIfNotBooted()
+    {
+        if (! isset(static::$booted[static::class])) {
+            static::$booted[static::class] = true;
+
+            static::bootTraits();
+        }
+    }
+
     protected static function bootTraits()
     {
         $class = static::class;

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -136,9 +136,22 @@ abstract class Resource
     private $alreadyFetchedRows;
 
     /**
+     * @var array The resources that have already been booted
+     */
+    protected static $booted = [];
+
+    /**
      * @return array array of fields
      */
     abstract public function fields();
+
+    public function __construct() {
+        if (! isset(static::$booted[static::class])) {
+            static::$booted[static::class] = true;
+
+            static::bootTraits();
+        }
+    }
 
     public function getFields(?bool $inline = false)
     {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -5,6 +5,7 @@ namespace BadChoice\Thrust;
 use BadChoice\Thrust\Actions\Delete;
 use BadChoice\Thrust\Actions\Import;
 use BadChoice\Thrust\Actions\MainAction;
+use BadChoice\Thrust\Concerns\BootableResource;
 use BadChoice\Thrust\Contracts\FormatsNewObject;
 use BadChoice\Thrust\Contracts\Prunable;
 use BadChoice\Thrust\Exceptions\CanNotDeleteException;
@@ -26,6 +27,8 @@ use Illuminate\Validation\ValidationException;
 
 abstract class Resource
 {
+    use BootableResource;
+
     /**
      * @var string defines the underlying model class
      */
@@ -133,39 +136,9 @@ abstract class Resource
     private $alreadyFetchedRows;
 
     /**
-     * @var array The resources that have already been booted
-     */
-    protected static $booted = [];
-
-    /**
      * @return array array of fields
      */
     abstract public function fields();
-
-    public function __construct() {
-        if (! isset(static::$booted[static::class])) {
-            static::$booted[static::class] = true;
-
-            static::bootTraits();
-        }
-    }
-
-    protected static function bootTraits()
-    {
-        $class = static::class;
-        
-        $booted = [];
-        
-        foreach (class_uses_recursive($class) as $trait) {
-            $method = 'boot'.class_basename($trait);
-
-            if (method_exists($class, $method) && ! in_array($method, $booted)) {
-                forward_static_call([$class, $method]);
-
-                $booted[] = $method;
-            }
-        }
-    }
 
     public function getFields(?bool $inline = false)
     {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -146,11 +146,7 @@ abstract class Resource
     abstract public function fields();
 
     public function __construct() {
-        if (! isset(static::$booted[static::class])) {
-            static::$booted[static::class] = true;
-
-            static::bootTraits();
-        }
+        static::bootIfNotBooted();
     }
 
     public function getFields(?bool $inline = false)


### PR DESCRIPTION
Això fa el mateix que Laravel amb el boot dels traits. 

Podeu mirar el construct de: [source](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Model.php)

Aixo ens permet fer refactor de traits de thrust perquè no tinguin conflictes al sobre-escriure creates / deletes.

Un exemple és aqui (li falta canvis al composer per afegir la versio de thrust amb aquest boot):  [PR](https://bitbucket.org/revo-pos/revo-back/pull-requests/6246)