### PR TITLE
bugfix: inline forms no longer register events

### DIFF
--- a/src/Controllers/ThrustController.php
+++ b/src/Controllers/ThrustController.php
@@ -40,7 +40,7 @@ class ThrustController extends Controller
         $resource = Thrust::make($resourceName);
         app(ResourceGate::class)->check($resource, 'create');
         $object = $resource->makeNew();
-        return (new Edit($resource))->show($object);
+        return (new Edit($resource))->show(id: $object, inline: request()->has('inline'));
     }
 
     public function createMultiple($resourceName)

--- a/src/Html/Edit.php
+++ b/src/Html/Edit.php
@@ -49,23 +49,24 @@ class Edit
         return $this->getIndexFields(true);
     }
 
-    public function show($id, $fullPage = false, $multiple = false)
+    public function show($id, $fullPage = false, $multiple = false, $inline = false)
     {
         view()->share('fullPage', $fullPage);
         $object = is_numeric($id) ? $this->resource->find($id) : $id;
         return view('thrust::edit', [
-            'title'                     => $this->resource->getTitle(),
-            'nameField'                 => $this->resource->nameField,
-            'breadcrumbs'               => $this->resource->breadcrumbs($object),
-            'resourceName'              => $this->resourceName ? : $this->resource->name(),
+            'title'                    => $this->resource->getTitle(),
+            'nameField'                => $this->resource->nameField,
+            'breadcrumbs'              => $this->resource->breadcrumbs($object),
+            'resourceName'             => $this->resourceName ? : $this->resource->name(),
             'fields'                    => $this->getEditFields($multiple),
-            'object'                    => $object,
-            'hideVisibility'            => Field::getPanelHideVisibilityJson(collect($this->resource->panels($object))),
-            'showVisibility'            => Field::getPanelShowVisibilityJson(collect($this->resource->panels($object))),
-            'fullPage'                  => $fullPage,
+            'object'                   => $object,
+            'hideVisibility'           => Field::getPanelHideVisibilityJson(collect($this->resource->panels($object))),
+            'showVisibility'           => Field::getPanelShowVisibilityJson(collect($this->resource->panels($object))),
+            'fullPage'                 => $fullPage,
             'updateConfirmationMessage' => $this->resource->getUpdateConfirmationMessage(),
-            'multiple'                  => $multiple,
-            'eventListeners'            => $this->resource->getValidationEventListeners(),
+            'multiple'                 => $multiple,
+            'eventListeners'           => $this->resource->getValidationEventListeners(),
+            'inline'                   => $inline, 
         ])->render();
     }
 

--- a/src/resources/views/components/fields/inlineCreationButton.blade.php
+++ b/src/resources/views/components/fields/inlineCreationButton.blade.php
@@ -7,7 +7,7 @@
 <script>
     function thrustCreateInline{{$field}}() {
         $("#inline-creation-{{$field}}").toggle('fast')
-        $("#inline-creation-{{$field}}").load('/thrust/{{$inlineCreationData['relationResource']}}/create', function(){
+        $("#inline-creation-{{$field}}").load('/thrust/{{$inlineCreationData['relationResource']}}/create?inline=true', function(){
             $('#inline-creation-{{$field}} form').on('submit', function(e){
                 e.preventDefault()
                 var form = $(this)

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -16,6 +16,7 @@
 <div x-data="{
         valid: true,
         init() {
+            if ('{{ $inline }}') return;
             this.$refs.editForm.addEventListener('submit', this.handleFormSubmit.bind(this));
         },
         handleFormSubmit(event) {


### PR DESCRIPTION
Aquest hotfix és per arreglar el creador de recursos de forma "inline", ja que aquest afegeix event listeners via jquery al arxiu "inlineCreationButton" i els formularis actuals estaven sobre-escrivint aquest funcionament